### PR TITLE
feat: initial file system operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,7 +170,16 @@ dependencies = [
 name = "bueno_ext"
 version = "0.0.1"
 dependencies = [
+ "bueno_ext_fs",
  "deno_core",
+]
+
+[[package]]
+name = "bueno_ext_fs"
+version = "0.0.1"
+dependencies = [
+ "deno_core",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,6 @@ members = ["ext", "bueno"]
 [workspace.dependencies]
 deno_core = "0.205.0"
 deno_ast = { version = "0.28.0", features = ["transpiling"] }
-clap = { version = "4.4.0", features = ["derive"] }
 tokio = { version = "1.19.2", features = ["full"] }
+
+bueno_ext = { path = "./ext/" }

--- a/bueno/Cargo.toml
+++ b/bueno/Cargo.toml
@@ -12,14 +12,16 @@ name = "bueno"
 path = "main.rs"
 
 [dependencies]
-deno_core = "0.205.0"
-deno_ast = { version = "0.28.0", features = ["transpiling"] }
-clap = { version = "4.4.0" }
-tokio = { version = "1.19.2", features = ["full"] }
+deno_core.workspace = true
+deno_ast.workspace = true
+tokio.workspace = true
+bueno_ext.workspace = true
+
+clap = "4.4.0"
 reqwest = "0.11.20"
 shellexpand = "3.1.0"
 
-bueno_ext = { path = "../ext" }
 
 [build-dependencies]
-deno_core = "0.205.0"
+deno_core.workspace = true
+bueno_ext.workspace = true

--- a/bueno/build.rs
+++ b/bueno/build.rs
@@ -1,24 +1,12 @@
 use std::env;
 use std::path::PathBuf;
 
+use bueno_ext::extensions::bueno;
+
 fn main() {
     // Build the file path to the snapshot.
     let out = PathBuf::from(env::var_os("OUT_DIR").unwrap());
     let snapshot_path = out.join("BUENO_RUNTIME_SNAPSHOT.bin");
-
-    deno_core::extension!(
-        bueno,
-        esm_entry_point = "ext:bueno/runtime.js",
-        esm = [
-            dir "../ext",
-
-            "bueno.js",
-            "console.js",
-            "runtime.js",
-            "io/mod.js",
-            "io/stdio.js",
-        ],
-    );
 
     // Create the snapshot.
     let output = deno_core::snapshot_util::create_snapshot(

--- a/ext/fs/Cargo.toml
+++ b/ext/fs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "bueno_ext"
-description = "Bueno runtime extensions"
+name = "bueno_ext_fs"
+description = "Bueno file system extension"
 edition.workspace = true
 version.workspace = true
 authors.workspace = true
@@ -12,4 +12,4 @@ path = "lib.rs"
 
 [dependencies]
 deno_core.workspace = true
-bueno_ext_fs = { path = "./fs/" }
+tokio.workspace = true

--- a/ext/fs/lib.rs
+++ b/ext/fs/lib.rs
@@ -1,70 +1,86 @@
-use deno_core::{error::AnyError, op, JsBuffer, ToJsBuffer};
+use deno_core::{error::AnyError, op, op2};
 
 // Read files
-#[op]
-pub async fn op_read_file(path: String) -> Result<ToJsBuffer, AnyError> {
+#[op2(async)]
+#[buffer]
+pub async fn op_read_file(#[string] path: String) -> Result<Vec<u8>, AnyError> {
     let contents = tokio::fs::read(path).await?;
-    Ok(contents.into())
+    Ok(contents)
 }
 
-#[op]
-pub fn op_read_file_sync(path: String) -> Result<ToJsBuffer, AnyError> {
+#[op2]
+#[buffer]
+pub fn op_read_file_sync(#[string] path: String) -> Result<Vec<u8>, AnyError> {
     let contents = std::fs::read(path)?;
-    Ok(contents.into())
+    Ok(contents)
 }
 
+// TODO: Convert it to op2
 #[op]
 pub async fn op_read_text_file(path: String) -> Result<String, AnyError> {
     let contents = tokio::fs::read_to_string(path).await?;
     Ok(contents)
 }
 
-#[op]
-pub fn op_read_text_file_sync(path: String) -> Result<String, AnyError> {
+#[op2]
+#[string]
+pub fn op_read_text_file_sync(#[string] path: String) -> Result<String, AnyError> {
     let contents = std::fs::read_to_string(path)?;
     Ok(contents)
 }
 
 // Write files
-#[op]
-pub async fn op_write_file(path: String, contents: JsBuffer) -> Result<(), AnyError> {
+#[op2(async)]
+pub async fn op_write_file(
+    #[string] path: String,
+    #[buffer(copy)] contents: Vec<u8>,
+) -> Result<(), AnyError> {
     tokio::fs::write(path, contents).await?;
     Ok(())
 }
 
-#[op]
-pub fn op_write_file_sync(path: String, contents: JsBuffer) -> Result<(), AnyError> {
+#[op2(fast)]
+pub fn op_write_file_sync(
+    #[string] path: String,
+    #[buffer(copy)] contents: Vec<u8>,
+) -> Result<(), AnyError> {
     std::fs::write(path, contents)?;
     Ok(())
 }
 
-#[op]
-pub async fn op_write_text_file(path: String, contents: String) -> Result<(), AnyError> {
+#[op2(async)]
+pub async fn op_write_text_file(
+    #[string] path: String,
+    #[string] contents: String,
+) -> Result<(), AnyError> {
     tokio::fs::write(path, contents).await?;
     Ok(())
 }
 
-#[op]
-pub fn op_write_text_file_sync(path: String, contents: String) -> Result<(), AnyError> {
+#[op2(fast)]
+pub fn op_write_text_file_sync(
+    #[string] path: String,
+    #[string] contents: String,
+) -> Result<(), AnyError> {
     std::fs::write(path, contents)?;
     Ok(())
 }
 
 // Remove files
-#[op]
-pub async fn op_remove_file(path: String) -> Result<(), AnyError> {
+#[op2(async)]
+pub async fn op_remove_file(#[string] path: String) -> Result<(), AnyError> {
     tokio::fs::remove_file(path).await?;
     Ok(())
 }
 
-#[op]
-pub fn op_remove_file_sync(path: String) -> Result<(), AnyError> {
+#[op2(fast)]
+pub fn op_remove_file_sync(#[string] path: String) -> Result<(), AnyError> {
     std::fs::remove_file(path)?;
     Ok(())
 }
 
-#[op]
-pub async fn op_remove_dir(path: String, recursive: bool) -> Result<(), AnyError> {
+#[op2(async)]
+pub async fn op_remove_dir(#[string] path: String, recursive: bool) -> Result<(), AnyError> {
     if recursive {
         tokio::fs::remove_dir_all(path).await?;
     } else {
@@ -74,8 +90,8 @@ pub async fn op_remove_dir(path: String, recursive: bool) -> Result<(), AnyError
     Ok(())
 }
 
-#[op]
-pub fn op_remove_dir_sync(path: String, recursive: bool) -> Result<(), AnyError> {
+#[op2(fast)]
+pub fn op_remove_dir_sync(#[string] path: String, recursive: bool) -> Result<(), AnyError> {
     if recursive {
         std::fs::remove_dir_all(path)?;
     } else {

--- a/ext/fs/lib.rs
+++ b/ext/fs/lib.rs
@@ -62,3 +62,25 @@ pub fn op_remove_file_sync(path: String) -> Result<(), AnyError> {
     std::fs::remove_file(path)?;
     Ok(())
 }
+
+#[op]
+pub async fn op_remove_dir(path: String, recursive: bool) -> Result<(), AnyError> {
+    if recursive {
+        tokio::fs::remove_dir_all(path).await?;
+    } else {
+        tokio::fs::remove_dir(path).await?;
+    }
+
+    Ok(())
+}
+
+#[op]
+pub fn op_remove_dir_sync(path: String, recursive: bool) -> Result<(), AnyError> {
+    if recursive {
+        std::fs::remove_dir_all(path)?;
+    } else {
+        std::fs::remove_dir(path)?;
+    }
+
+    Ok(())
+}

--- a/ext/fs/lib.rs
+++ b/ext/fs/lib.rs
@@ -1,0 +1,64 @@
+use deno_core::{error::AnyError, op, JsBuffer, ToJsBuffer};
+
+// Read files
+#[op]
+pub async fn op_read_file(path: String) -> Result<ToJsBuffer, AnyError> {
+    let contents = tokio::fs::read(path).await?;
+    Ok(contents.into())
+}
+
+#[op]
+pub fn op_read_file_sync(path: String) -> Result<ToJsBuffer, AnyError> {
+    let contents = std::fs::read(path)?;
+    Ok(contents.into())
+}
+
+#[op]
+pub async fn op_read_text_file(path: String) -> Result<String, AnyError> {
+    let contents = tokio::fs::read_to_string(path).await?;
+    Ok(contents)
+}
+
+#[op]
+pub fn op_read_text_file_sync(path: String) -> Result<String, AnyError> {
+    let contents = std::fs::read_to_string(path)?;
+    Ok(contents)
+}
+
+// Write files
+#[op]
+pub async fn op_write_file(path: String, contents: JsBuffer) -> Result<(), AnyError> {
+    tokio::fs::write(path, contents).await?;
+    Ok(())
+}
+
+#[op]
+pub fn op_write_file_sync(path: String, contents: JsBuffer) -> Result<(), AnyError> {
+    std::fs::write(path, contents)?;
+    Ok(())
+}
+
+#[op]
+pub async fn op_write_text_file(path: String, contents: String) -> Result<(), AnyError> {
+    tokio::fs::write(path, contents).await?;
+    Ok(())
+}
+
+#[op]
+pub fn op_write_text_file_sync(path: String, contents: String) -> Result<(), AnyError> {
+    std::fs::write(path, contents)?;
+    Ok(())
+}
+
+// Remove files
+#[op]
+pub async fn op_remove_file(path: String) -> Result<(), AnyError> {
+    tokio::fs::remove_file(path).await?;
+    Ok(())
+}
+
+#[op]
+pub fn op_remove_file_sync(path: String) -> Result<(), AnyError> {
+    std::fs::remove_file(path)?;
+    Ok(())
+}

--- a/ext/fs/mod.js
+++ b/ext/fs/mod.js
@@ -1,7 +1,7 @@
 const core = Bueno.core;
 
 /**
- * Reads a file asyncronously
+ * Reads a file asynchronously
  * @param {string} path
  * @returns {Promise<Uint8Array>}
  */
@@ -10,7 +10,7 @@ function readFile(path) {
 }
 
 /**
- * Reads a file syncronously
+ * Reads a file synchronously
  * @param {string} path
  * @returns {Uint8Array}
  */
@@ -19,7 +19,7 @@ function readFileSync(path) {
 }
 
 /**
- * Reads a text file asyncronously
+ * Reads a text file synchronously
  * @param {string} path
  * @returns {Promise<string>}
  */
@@ -28,7 +28,7 @@ function readTextFile(path) {
 }
 
 /**
- * Reads a text file syncronously
+ * Reads a text file synchronously
  * @param {string} path
  * @returns {string}
  */
@@ -37,7 +37,7 @@ function readTextFileSync(path) {
 }
 
 /**
- * Writes a file asyncronously
+ * Writes a file asynchronously
  * @param {string} path
  * @param {Uint8Array} contents
  * @returns {Promise<void>}
@@ -47,7 +47,7 @@ function writeFile(path, contents) {
 }
 
 /**
- * Writes a file syncronously
+ * Writes a file synchronously
  * @param {string} path
  * @param {Uint8Array} contents
  * @returns {void}
@@ -57,7 +57,7 @@ function writeFileSync(path, contents) {
 }
 
 /**
- * Writes a text file asyncronously
+ * Writes a text file asynchronously
  * @param {string} path
  * @param {string} contents
  * @returns {Promise<void>}
@@ -67,7 +67,7 @@ function writeTextFile(path, contents) {
 }
 
 /**
- * Writes a text file syncronously
+ * Writes a text file synchronously
  * @param {string} path
  * @param {string} contents
  * @returns {void}
@@ -77,21 +77,41 @@ function writeTextFileSync(path, contents) {
 }
 
 /**
- * Deletes file asyncronously
+ * Deletes file asynchronously
  * @param {string} path
  * @returns {Promise<void>}
  */
-function remove(path) {
+function removeFile(path) {
   core.ops.op_remove_file(path);
 }
 
 /**
- * Deletes file syncronously
+ * Deletes file synchronously
  * @param {string} path
  * @returns {void}
  */
-function removeSync(path) {
+function removeFileSync(path) {
   core.ops.op_remove_file_sync(path);
+}
+
+/**
+ * Deletes directory asynchronously
+ * @param {string} path
+ * @param {boolean} recursive
+ * @returns {Promise<void>}
+ */
+function removeDirectory(path, recursive) {
+  core.ops.op_remove_dir(path, recursive);
+}
+
+/**
+ * Deletes directory synchronously
+ * @param {string} path
+ * @param {boolean} recursive
+ * @returns {void}
+ */
+function removeDirectorySync(path, recursive) {
+  core.ops.op_remove_dir_sync(path, recursive);
 }
 
 Bueno.fs = {
@@ -103,6 +123,8 @@ Bueno.fs = {
   writeFileSync,
   writeTextFile,
   writeTextFileSync,
-  remove,
-  removeSync,
+  removeFile,
+  removeFileSync,
+  removeDirectory,
+  removeDirectorySync,
 };

--- a/ext/fs/mod.js
+++ b/ext/fs/mod.js
@@ -1,0 +1,108 @@
+const core = Bueno.core;
+
+/**
+ * Reads a file asyncronously
+ * @param {string} path
+ * @returns {Promise<Uint8Array>}
+ */
+function readFile(path) {
+  return core.ops.op_read_file(path);
+}
+
+/**
+ * Reads a file syncronously
+ * @param {string} path
+ * @returns {Uint8Array}
+ */
+function readFileSync(path) {
+  return core.ops.op_read_file_sync(path);
+}
+
+/**
+ * Reads a text file asyncronously
+ * @param {string} path
+ * @returns {Promise<string>}
+ */
+function readTextFile(path) {
+  return core.ops.op_read_text_file(path);
+}
+
+/**
+ * Reads a text file syncronously
+ * @param {string} path
+ * @returns {string}
+ */
+function readTextFileSync(path) {
+  return core.ops.op_read_text_file_sync(path);
+}
+
+/**
+ * Writes a file asyncronously
+ * @param {string} path
+ * @param {Uint8Array} contents
+ * @returns {Promise<void>}
+ */
+function writeFile(path, contents) {
+  core.ops.op_write_file(path, contents);
+}
+
+/**
+ * Writes a file syncronously
+ * @param {string} path
+ * @param {Uint8Array} contents
+ * @returns {void}
+ */
+function writeFileSync(path, contents) {
+  core.ops.op_write_file_sync(path, contents);
+}
+
+/**
+ * Writes a text file asyncronously
+ * @param {string} path
+ * @param {string} contents
+ * @returns {Promise<void>}
+ */
+function writeTextFile(path, contents) {
+  core.ops.op_write_text_file(path, contents);
+}
+
+/**
+ * Writes a text file syncronously
+ * @param {string} path
+ * @param {string} contents
+ * @returns {void}
+ */
+function writeTextFileSync(path, contents) {
+  core.ops.op_write_text_file_sync(path, contents);
+}
+
+/**
+ * Deletes file asyncronously
+ * @param {string} path
+ * @returns {Promise<void>}
+ */
+function remove(path) {
+  core.ops.op_remove_file(path);
+}
+
+/**
+ * Deletes file syncronously
+ * @param {string} path
+ * @returns {void}
+ */
+function removeSync(path) {
+  core.ops.op_remove_file_sync(path);
+}
+
+Bueno.fs = {
+  readFile,
+  readFileSync,
+  readTextFile,
+  readTextFileSync,
+  writeFile,
+  writeFileSync,
+  writeTextFile,
+  writeTextFileSync,
+  remove,
+  removeSync,
+};

--- a/ext/lib.rs
+++ b/ext/lib.rs
@@ -1,6 +1,23 @@
 pub mod extensions {
+    use bueno_ext_fs as fs;
+
     deno_core::extension!(
         bueno,
+        ops = [
+            // read
+            fs::op_read_file,
+            fs::op_read_file_sync,
+            fs::op_read_text_file,
+            fs::op_read_text_file_sync,
+            // write
+            fs::op_write_file,
+            fs::op_write_file_sync,
+            fs::op_write_text_file,
+            fs::op_write_text_file_sync,
+            // remove
+            fs::op_remove_file,
+            fs::op_remove_file_sync
+        ],
         esm_entry_point = "ext:bueno/runtime.js",
         esm = [
             "bueno.js",
@@ -8,6 +25,7 @@ pub mod extensions {
             "runtime.js",
             "io/mod.js",
             "io/stdio.js",
+            "fs/mod.js"
         ],
     );
 

--- a/ext/runtime.js
+++ b/ext/runtime.js
@@ -2,3 +2,4 @@ import "ext:bueno/bueno.js";
 import "ext:bueno/console.js";
 
 import "ext:bueno/io/mod.js";
+import "ext:bueno/fs/mod.js";


### PR DESCRIPTION
Follow up to #3, most of the code has been reused.
This PR adds support for these API's (#6):
 - `fs`
   - [x] `readFile` – async read file and return `Uint8Array`
   - [x] `readFileSync` – sync version of `fs.readFile`
   - [x] `readTextFile` – async read file and return `string`
   - [x] `readTextFileSync` – sync version of `fs.readTextFile`
   - [x] `writeFile` – async write file using `Uint8Array`
   - [x] `writeFileSync` – sync version of `fs.writeFile`
   - [x] `writeTextFile` – async write file using `string`
   - [x] `writeTextFileSync` – sync version of `fs.readTextFile`
   - [x] `removeFile` - asynchronously delete file
   - [x] `removeFileSync` - sync version of `fs.removeFile`
   - [x] `removeDirectory` - asynchronously delete directory
   - [x] `removeDirectorySync` - sync version of `fs.removeDirectory`
 
~~This PR doesn't use `op2`'s, it can be done as a follow up~~
Most of the ops have been converted to `op2`, the only one that isn't is `op_read_text_file`