### PR TITLE
feat: Enforce asynchronous operations on FS/IO

### DIFF
--- a/ext/fs/lib.rs
+++ b/ext/fs/lib.rs
@@ -8,24 +8,10 @@ pub async fn op_read_file(#[string] path: String) -> Result<Vec<u8>, AnyError> {
     Ok(contents)
 }
 
-#[op2]
-#[buffer]
-pub fn op_read_file_sync(#[string] path: String) -> Result<Vec<u8>, AnyError> {
-    let contents = std::fs::read(path)?;
-    Ok(contents)
-}
-
 #[op2(async)]
 #[string]
 pub async fn op_read_text_file(#[string] path: String) -> Result<String, AnyError> {
     let contents = tokio::fs::read_to_string(path).await?;
-    Ok(contents)
-}
-
-#[op2]
-#[string]
-pub fn op_read_text_file_sync(#[string] path: String) -> Result<String, AnyError> {
-    let contents = std::fs::read_to_string(path)?;
     Ok(contents)
 }
 
@@ -39,30 +25,12 @@ pub async fn op_write_file(
     Ok(())
 }
 
-#[op2(fast)]
-pub fn op_write_file_sync(
-    #[string] path: String,
-    #[buffer(copy)] contents: Vec<u8>,
-) -> Result<(), AnyError> {
-    std::fs::write(path, contents)?;
-    Ok(())
-}
-
 #[op2(async)]
 pub async fn op_write_text_file(
     #[string] path: String,
     #[string] contents: String,
 ) -> Result<(), AnyError> {
     tokio::fs::write(path, contents).await?;
-    Ok(())
-}
-
-#[op2(fast)]
-pub fn op_write_text_file_sync(
-    #[string] path: String,
-    #[string] contents: String,
-) -> Result<(), AnyError> {
-    std::fs::write(path, contents)?;
     Ok(())
 }
 
@@ -73,29 +41,12 @@ pub async fn op_remove_file(#[string] path: String) -> Result<(), AnyError> {
     Ok(())
 }
 
-#[op2(fast)]
-pub fn op_remove_file_sync(#[string] path: String) -> Result<(), AnyError> {
-    std::fs::remove_file(path)?;
-    Ok(())
-}
-
 #[op2(async)]
 pub async fn op_remove_dir(#[string] path: String, recursive: bool) -> Result<(), AnyError> {
     if recursive {
         tokio::fs::remove_dir_all(path).await?;
     } else {
         tokio::fs::remove_dir(path).await?;
-    }
-
-    Ok(())
-}
-
-#[op2(fast)]
-pub fn op_remove_dir_sync(#[string] path: String, recursive: bool) -> Result<(), AnyError> {
-    if recursive {
-        std::fs::remove_dir_all(path)?;
-    } else {
-        std::fs::remove_dir(path)?;
     }
 
     Ok(())

--- a/ext/fs/mod.js
+++ b/ext/fs/mod.js
@@ -10,30 +10,12 @@ function readFile(path) {
 }
 
 /**
- * Reads a file synchronously
- * @param {string} path
- * @returns {Uint8Array}
- */
-function readFileSync(path) {
-  return core.ops.op_read_file_sync(path);
-}
-
-/**
  * Reads a text file synchronously
  * @param {string} path
  * @returns {Promise<string>}
  */
 function readTextFile(path) {
   return core.ops.op_read_text_file(path);
-}
-
-/**
- * Reads a text file synchronously
- * @param {string} path
- * @returns {string}
- */
-function readTextFileSync(path) {
-  return core.ops.op_read_text_file_sync(path);
 }
 
 /**
@@ -47,16 +29,6 @@ function writeFile(path, contents) {
 }
 
 /**
- * Writes a file synchronously
- * @param {string} path
- * @param {Uint8Array} contents
- * @returns {void}
- */
-function writeFileSync(path, contents) {
-  core.ops.op_write_file_sync(path, contents);
-}
-
-/**
  * Writes a text file asynchronously
  * @param {string} path
  * @param {string} contents
@@ -64,16 +36,6 @@ function writeFileSync(path, contents) {
  */
 function writeTextFile(path, contents) {
   core.ops.op_write_text_file(path, contents);
-}
-
-/**
- * Writes a text file synchronously
- * @param {string} path
- * @param {string} contents
- * @returns {void}
- */
-function writeTextFileSync(path, contents) {
-  core.ops.op_write_text_file_sync(path, contents);
 }
 
 /**
@@ -86,15 +48,6 @@ function removeFile(path) {
 }
 
 /**
- * Deletes file synchronously
- * @param {string} path
- * @returns {void}
- */
-function removeFileSync(path) {
-  core.ops.op_remove_file_sync(path);
-}
-
-/**
  * Deletes directory asynchronously
  * @param {string} path
  * @param {boolean} recursive
@@ -104,27 +57,11 @@ function removeDirectory(path, recursive) {
   core.ops.op_remove_dir(path, recursive);
 }
 
-/**
- * Deletes directory synchronously
- * @param {string} path
- * @param {boolean} recursive
- * @returns {void}
- */
-function removeDirectorySync(path, recursive) {
-  core.ops.op_remove_dir_sync(path, recursive);
-}
-
 Bueno.fs = {
   readFile,
-  readFileSync,
   readTextFile,
-  readTextFileSync,
   writeFile,
-  writeFileSync,
   writeTextFile,
-  writeTextFileSync,
   removeFile,
-  removeFileSync,
   removeDirectory,
-  removeDirectorySync,
 };

--- a/ext/io/mod.js
+++ b/ext/io/mod.js
@@ -15,18 +15,6 @@ async function read(rid, buffer) {
 }
 
 /**
- * Read resource id synchronously
- * @param {number} rid resource id
- * @param {Uint8Array} buffer buffer to read to
- * @returns number of bytes that has been read or `null` (EOF)
- */
-function readSync(rid, buffer) {
-  // Can't read into nothing
-  if (buffer.length === 0) return 0;
-  return core.readSync(rid) || null;
-}
-
-/**
  * Write data to resource id asynchronously
  * @param {number} rid resource id
  * @param {Uint8Array} data buffer to write
@@ -34,16 +22,6 @@ function readSync(rid, buffer) {
  */
 function write(rid, data) {
   return core.write(rid, data);
-}
-
-/**
- * Write data to resource id synchronously
- * @param {number} rid resource id
- * @param {Uint8Array} data buffer to write
- * @returns number of bytes that has been written
- */
-function writeSync(rid, data) {
-  return core.writeSync(rid, data);
 }
 
 /**
@@ -56,9 +34,7 @@ function close(rid) {
 
 Bueno.io = {
   read,
-  readSync,
   write,
-  writeSync,
   close,
 
   stdin: new Stdin(),

--- a/ext/io/stdio.js
+++ b/ext/io/stdio.js
@@ -1,14 +1,14 @@
 class SharedStdio {
   write(data) {
-    return write(this.rid, data);
+    return Bueno.io.write(this.rid, data);
   }
 
   read(buffer) {
-    return read(this.rid, buffer);
+    return Bueno.io.read(this.rid, buffer);
   }
 
   close() {
-    close(this.rid);
+    Bueno.io.close(this.rid);
   }
 }
 

--- a/ext/lib.rs
+++ b/ext/lib.rs
@@ -6,17 +6,13 @@ pub mod extensions {
         ops = [
             // read
             fs::op_read_file,
-            fs::op_read_file_sync,
             fs::op_read_text_file,
-            fs::op_read_text_file_sync,
             // write
             fs::op_write_file,
-            fs::op_write_file_sync,
             fs::op_write_text_file,
-            fs::op_write_text_file_sync,
             // remove
             fs::op_remove_file,
-            fs::op_remove_file_sync
+            fs::op_remove_dir,
         ],
         esm_entry_point = "ext:bueno/runtime.js",
         esm = [


### PR DESCRIPTION
This removes synchronous versions of `Bueno.fs` and `Bueno.io` operations.
They're an anti-pattern, synchronous API's block everything in tokio's event loop.