### PR TITLE
feat: incomplete `Performance` api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,11 +171,20 @@ name = "bueno_ext"
 version = "0.0.1"
 dependencies = [
  "bueno_ext_fs",
+ "bueno_ext_performance",
  "deno_core",
 ]
 
 [[package]]
 name = "bueno_ext_fs"
+version = "0.0.1"
+dependencies = [
+ "deno_core",
+ "tokio",
+]
+
+[[package]]
+name = "bueno_ext_performance"
 version = "0.0.1"
 dependencies = [
  "deno_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace.package]
-name = "buenojs"
 version = "0.0.1"
+name = "buenojs"
 edition = "2021"
 license = "MIT"
 authors = ["The Bueno Team"]

--- a/examples/run.ts
+++ b/examples/run.ts
@@ -180,7 +180,7 @@ console.warn("More of level 3");
 console.groupEnd();
 console.log("Back to level 2");
 console.groupEnd();
-console.log("Back to the outer level"); 
+console.log("Back to the outer level");
 
 console.group();
 console.group();
@@ -209,3 +209,22 @@ console.table([tyrone, janet, maria], ["firstName"]);
 console.table([tyrone, janet, maria], ["lastName"]);
 console.table([tyrone, janet, maria], ["firstName", "lastName"]);
 
+const start = performance.now();
+console.log(start);
+
+for (let i = 0; i < 100_000; ++i) {
+  Math.random();
+}
+
+const end = performance.now();
+console.log(end);
+console.log("Elapsed:", end - start);
+
+console.log("ORIGIN:", performance.timeOrigin);
+console.log(
+  "date-performance.timeOrigin vs performance.now",
+  Date.now() - performance.timeOrigin,
+  performance.now(),
+);
+
+console.log(Date.now());

--- a/ext/lib.rs
+++ b/ext/lib.rs
@@ -1,18 +1,20 @@
 pub mod extensions {
+    use std::time::{Instant, SystemTime};
+
     use bueno_ext_fs as fs;
+    use bueno_ext_performance as performance;
 
     deno_core::extension!(
         bueno,
         ops = [
-            // read
             fs::op_read_file,
             fs::op_read_text_file,
-            // write
             fs::op_write_file,
             fs::op_write_text_file,
-            // remove
             fs::op_remove_file,
             fs::op_remove_dir,
+            performance::op_high_res_time,
+            performance::op_time_origin,
         ],
         esm_entry_point = "ext:bueno/runtime.js",
         esm = [
@@ -24,8 +26,16 @@ pub mod extensions {
             "console/mod.js",
             "console/printer.js",
             "console/formatter.js",
-            "console/table.js"
+            "console/table.js",
+            "performance/mod.js",
         ],
+        state = |state| {
+            {
+                // bun_ext_perf
+                state.put(Instant::now());
+                state.put(SystemTime::now());
+            };
+        }
     );
 
     deno_core::extension!(

--- a/ext/performance/Cargo.toml
+++ b/ext/performance/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "bueno_ext"
-description = "Bueno runtime extensions"
+name = "bueno_ext_performance"
+description = "Bueno Performance extension"
 edition.workspace = true
 version.workspace = true
 authors.workspace = true
@@ -12,5 +12,4 @@ path = "lib.rs"
 
 [dependencies]
 deno_core.workspace = true
-bueno_ext_fs = { path = "./fs/" }
-bueno_ext_performance = { path = "./performance/" }
+tokio.workspace = true

--- a/ext/performance/lib.rs
+++ b/ext/performance/lib.rs
@@ -1,0 +1,27 @@
+use deno_core::{error::AnyError, op2, OpState};
+use std::time::{Instant, SystemTime};
+
+const NS_IN_MS: f64 = 1e+6;
+
+// Returns time in milliseconds with nanosecond precision since runtime's start
+#[op2(fast)]
+pub fn op_high_res_time(state: &mut OpState) -> f64 {
+    let origin_time = state.borrow::<Instant>();
+
+    let elapsed_ns = origin_time.elapsed().subsec_nanos();
+    // TODO: coarsen time whenever necessary
+
+    elapsed_ns as f64 / NS_IN_MS
+}
+
+// Returns time in milliseconds with nanosecond precision since unix epoch
+#[op2(fast)]
+pub fn op_time_origin(state: &mut OpState) -> Result<f64, AnyError> {
+    let origin_time = state.borrow::<SystemTime>();
+
+    let duration_ms = origin_time
+        .duration_since(SystemTime::UNIX_EPOCH)?
+        .as_nanos();
+
+    Ok(duration_ms as f64 / NS_IN_MS)
+}

--- a/ext/performance/mod.js
+++ b/ext/performance/mod.js
@@ -1,0 +1,26 @@
+import "ext:bueno/console/mod.js";
+
+const core = Bueno.core;
+
+// TODO(Im-Beast): Implement other Performance methods
+export class Performance {
+  #timeOrigin;
+
+  now() {
+    return core.ops.op_high_res_time();
+  }
+
+  get timeOrigin() {
+    this.#timeOrigin ??= core.ops.op_time_origin();
+    return this.#timeOrigin;
+  }
+
+  toJSON() {
+    return {
+      timeOrigin: this.timeOrigin,
+    };
+  }
+}
+
+globalThis.Performance == Performance;
+globalThis.performance = new Performance();

--- a/ext/runtime.js
+++ b/ext/runtime.js
@@ -3,3 +3,4 @@ import "ext:bueno/bueno.js";
 import "ext:bueno/io/mod.js";
 import "ext:bueno/fs/mod.js";
 import "ext:bueno/console/mod.js";
+import "ext:bueno/performance/mod.js";


### PR DESCRIPTION
This PR adds very incomplete support for `Performance` API.
This is just so creating testing/benchmarking API can be done ASAP.

It adds these `performance` api's:
 - `now`
 - `timeOrigin`
 - `toJSON`