### PR TITLE
feat: allow typescript in sable extensions

### DIFF
--- a/ext/battery/mod.ts
+++ b/ext/battery/mod.ts
@@ -1,66 +1,66 @@
 import {
-	op_battery_charging,
-	op_battery_charging_time,
-	op_battery_discharging_time,
-	op_battery_level,
+  op_battery_charging,
+  op_battery_charging_time,
+  op_battery_discharging_time,
+  op_battery_level,
 } from "ext:core/ops";
 
 class BatteryManager extends EventTarget {
-	get charging() {
-		return op_battery_charging();
-	}
+  get charging() {
+    return op_battery_charging();
+  }
 
-	get chargingTime() {
-		return op_battery_charging_time();
-	}
+  get chargingTime() {
+    return op_battery_charging_time();
+  }
 
-	get dischargingTime() {
-		return op_battery_discharging_time();
-	}
+  get dischargingTime() {
+    return op_battery_discharging_time();
+  }
 
-	get level() {
-		return op_battery_level();
-	}
+  get level() {
+    return op_battery_level();
+  }
 }
 
 let batteryManager;
 
 globalThis.navigator.getBattery = async () => {
-	if (!batteryManager) {
-		batteryManager = new BatteryManager();
+  if (!batteryManager) {
+    batteryManager = new BatteryManager();
 
-		let oldCharging = batteryManager.charging;
-		let oldChargingTime = batteryManager.chargingTime;
-		let oldDischargingTime = batteryManager.dischargingTime;
-		let oldLevel = batteryManager.level;
+    let oldCharging = batteryManager.charging;
+    let oldChargingTime = batteryManager.chargingTime;
+    let oldDischargingTime = batteryManager.dischargingTime;
+    let oldLevel = batteryManager.level;
 
-		setInterval(() => {
-			const newCharging = batteryManager.charging;
-			const newChargingTime = batteryManager.chargingTime;
-			const newDischargingTime = batteryManager.dischargingTime;
-			const newLevel = batteryManager.level;
+    setInterval(() => {
+      const newCharging = batteryManager.charging;
+      const newChargingTime = batteryManager.chargingTime;
+      const newDischargingTime = batteryManager.dischargingTime;
+      const newLevel = batteryManager.level;
 
-			if (oldCharging !== newCharging) {
-				batteryManager?.onchargingchange();
-				batteryManager.dispatchEvent(new Event("chargingchange"));
-			}
-			if (oldChargingTime !== newChargingTime) {
-				batteryManager?.onchargingtimechange();
-				batteryManager.dispatchEvent(new Event("chargingtimechange"));
-			}
-			if (oldDischargingTime !== newDischargingTime) {
-				batteryManager?.ondischargingtimechange();
-				batteryManager.dispatchEvent(new Event("dischargingtimechange"));
-			}
-			if (oldLevel !== newLevel) {
-				batteryManager?.onlevelchange();
-				batteryManager.dispatchEvent(new Event("levelchange"));
-			}
-			oldCharging = newCharging;
-			oldChargingTime = newChargingTime;
-			oldDischargingTime = newDischargingTime;
-			oldLevel = newLevel;
-		}, 1000);
-	}
-	return batteryManager;
+      if (oldCharging !== newCharging) {
+        batteryManager?.onchargingchange();
+        batteryManager.dispatchEvent(new Event("chargingchange"));
+      }
+      if (oldChargingTime !== newChargingTime) {
+        batteryManager?.onchargingtimechange();
+        batteryManager.dispatchEvent(new Event("chargingtimechange"));
+      }
+      if (oldDischargingTime !== newDischargingTime) {
+        batteryManager?.ondischargingtimechange();
+        batteryManager.dispatchEvent(new Event("dischargingtimechange"));
+      }
+      if (oldLevel !== newLevel) {
+        batteryManager?.onlevelchange();
+        batteryManager.dispatchEvent(new Event("levelchange"));
+      }
+      oldCharging = newCharging;
+      oldChargingTime = newChargingTime;
+      oldDischargingTime = newDischargingTime;
+      oldLevel = newLevel;
+    }, 1000);
+  }
+  return batteryManager;
 };

--- a/ext/battery/mod.ts
+++ b/ext/battery/mod.ts
@@ -1,4 +1,9 @@
-import { op_battery_charging, op_battery_charging_time, op_battery_discharging_time, op_battery_level} from "ext:core/ops"
+import {
+	op_battery_charging,
+	op_battery_charging_time,
+	op_battery_discharging_time,
+	op_battery_level,
+} from "ext:core/ops";
 
 class BatteryManager extends EventTarget {
 	get charging() {

--- a/ext/lib.rs
+++ b/ext/lib.rs
@@ -39,7 +39,7 @@ pub mod extensions {
             "io/mod.js",
             "io/stdio.js",
             "fs/mod.js",
-            "battery/mod.js",
+            "battery/mod.ts",
             "web/mod.js",
             "web/events.js",
             "web/encoding.js",

--- a/ext/runtime.js
+++ b/ext/runtime.js
@@ -3,7 +3,7 @@ import "ext:sable/sable.js";
 import "ext:sable/web/mod.js";
 import "ext:sable/io/mod.js";
 import "ext:sable/fs/mod.js";
-import "ext:sable/battery/mod.js";
+import "ext:sable/battery/mod.ts";
 import "ext:sable/console/mod.js";
 import "ext:sable/performance/mod.js";
 import "ext:sable/timers/mod.js";

--- a/ext/tsconfig.d.ts
+++ b/ext/tsconfig.d.ts
@@ -15,6 +15,12 @@ declare module "ext:core/ops" {
   // sable
   export function op_runtime_state(): "default" | "test" | "bench";
 
+  // battery
+  export function op_battery_charging(): boolean;
+  export function op_battery_charging_time(): number;
+  export function op_battery_discharging_time(): number;
+  export function op_battery_level(): number;
+
   // fs
   export function op_read_text_file(path: string): Promise<string>;
   export function op_write_text_file(path: string, data: string): Promise<void>;

--- a/sable/Cargo.toml
+++ b/sable/Cargo.toml
@@ -28,4 +28,5 @@ dprint-plugin-typescript = "=0.88.10"
 
 [build-dependencies]
 deno_core.workspace = true
+deno_ast.workspace = true
 sable_ext.workspace = true

--- a/sable/build.rs
+++ b/sable/build.rs
@@ -1,19 +1,47 @@
+use std::borrow::Cow;
 use std::fs::File;
 use std::path::PathBuf;
+use std::rc::Rc;
 use std::{env, io::Write};
 
-use sable_ext::extensions::sable;
+use deno_ast::{parse_module, MediaType, ParseParams, SourceTextInfo};
 use deno_core::snapshot::{create_snapshot, CreateSnapshotOptions};
+use deno_core::FastString;
+use sable_ext::extensions::sable;
 
 fn main() {
     // Build the file path to the snapshot.
     let out = PathBuf::from(env::var_os("OUT_DIR").unwrap());
     let snapshot_path = out.join("SABLE_RUNTIME_SNAPSHOT.bin");
 
+    let ts_transpiler = Rc::new(|module_name: FastString, code_string: FastString| {
+        if module_name.ends_with(".ts") {
+            let parsed = parse_module(ParseParams {
+                specifier: module_name.to_string(),
+                text_info: SourceTextInfo::from_string(code_string.to_string()),
+                media_type: MediaType::TypeScript,
+                capture_tokens: false,
+                scope_analysis: false,
+                maybe_syntax: None,
+            })?;
+
+            let transpiled = parsed.transpile(&Default::default())?;
+
+            Ok((
+                transpiled.text.into(),
+                transpiled
+                    .source_map
+                    .map(|str| Cow::Owned(str.into_bytes())),
+            ))
+        } else {
+            Ok((code_string, None))
+        }
+    });
+
     // Create the snapshot.
     let output = create_snapshot(
         CreateSnapshotOptions {
-            extension_transpiler: None,
+            extension_transpiler: Some(ts_transpiler),
             skip_op_registration: false,
             cargo_manifest_dir: env!("CARGO_MANIFEST_DIR"),
             extensions: vec![sable::init_ops_and_esm()],


### PR DESCRIPTION
Allows us to use TypeScript in `ext`. This doesn't expose TypeScript to users in any way.