### PR TITLE
fix: `fmt` subcommand creating racing conditions due to `atomic_write`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,6 +314,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
+name = "const_format"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a214c7af3d04997541b18d432afaff4c455e79e2029079647e72fc2bd27673"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f6ff08fd20f4f299298a28e2dfa8a8ba1036e6cd2460ac1de7b425d76f2500"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "cooked-waker"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -892,12 +912,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
-name = "glob"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
-
-[[package]]
 name = "gzip-header"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1143,6 +1157,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
 
 [[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1265,6 +1288,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1317,6 +1346,16 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1550,6 +1589,15 @@ name = "pkg-config"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+
+[[package]]
+name = "pori"
+version = "0.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a63d338dec139f56dacc692ca63ad35a6be6a797442479b55acd611d79e906"
+dependencies = [
+ "nom",
+]
 
 [[package]]
 name = "proc-macro-rules"
@@ -1928,11 +1976,20 @@ dependencies = [
  "dprint-plugin-json",
  "dprint-plugin-markdown",
  "dprint-plugin-typescript",
- "glob",
  "reqwest",
  "sable_ext",
  "shellexpand",
  "tokio",
+ "wax",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -2873,6 +2930,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
 name = "uom"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2935,6 +2998,16 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -3016,6 +3089,21 @@ name = "wasm-bindgen-shared"
 version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+
+[[package]]
+name = "wax"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d12a78aa0bab22d2f26ed1a96df7ab58e8a93506a3e20adb47c51a93b4e1357"
+dependencies = [
+ "const_format",
+ "itertools",
+ "nom",
+ "pori",
+ "regex",
+ "thiserror",
+ "walkdir",
+]
 
 [[package]]
 name = "web-sys"

--- a/sable/Cargo.toml
+++ b/sable/Cargo.toml
@@ -20,7 +20,7 @@ sable_ext.workspace = true
 clap = "4.5.6"
 reqwest = "0.12.4"
 shellexpand = "3.1.0"
-glob = "0.3.1"
+wax = "0.6.0"
 
 dprint-plugin-json = "=0.19.3"
 dprint-plugin-markdown = "=0.17.1"

--- a/sable/module_cache.rs
+++ b/sable/module_cache.rs
@@ -51,7 +51,7 @@ impl ModuleCache {
             ModuleSourceCode::Bytes(bytes) => bytes.as_bytes(),
             ModuleSourceCode::String(string) => string.as_bytes(),
         };
-        atomic_write(&cache_path, bytes).await?;
+        atomic_write(&cache_path, bytes, 0o644).await?;
 
         Ok(())
     }

--- a/sable/utils/fs.rs
+++ b/sable/utils/fs.rs
@@ -5,24 +5,36 @@ use std::path::{Path, PathBuf};
 use tokio::fs;
 use tokio::io::AsyncWriteExt;
 
-pub async fn atomic_write(path: impl AsRef<Path>, data: impl AsRef<[u8]>) -> Result<(), Error> {
-    let temp_path = PathBuf::from(shellexpand::full("~/.cache/sable/temp")?.into_owned());
+pub async fn atomic_write(path: &Path, data: impl AsRef<[u8]>, mode: u32) -> Result<(), Error> {
+    let temp_path = PathBuf::from(shellexpand::full("~/.cache/sable/tmp")?.into_owned());
+    let file_path = temp_path.join(path);
 
-    if temp_path.try_exists().is_err() {
-        fs::create_dir_all(temp_path.parent().unwrap()).await?;
+    // Make sure parent of the file exists
+    let parent = file_path.parent().unwrap();
+    if let Ok(false) | Err(_) = parent.try_exists() {
+        fs::create_dir_all(&parent).await?;
     }
 
     let mut file = fs::OpenOptions::new()
         .write(true)
         .create(true)
         .truncate(true)
-        .open(&temp_path)
+        .mode(mode)
+        .open(&file_path)
         .await?;
 
     file.write_all(data.as_ref()).await?;
     file.sync_all().await?;
 
-    fs::rename(&temp_path, path).await?;
+    match fs::rename(&file_path, path).await {
+        // If rename fails, it might be because its on a different mount point
+        // Try to copy it there instead
+        Err(_) => {
+            fs::copy(&file_path, path).await?;
+            fs::remove_file(&file_path).await?;
+        }
+        _ => {}
+    }
 
     Ok(())
 }


### PR DESCRIPTION
Additionally replaces `glob` with `wax` which is a little bit more customizable.
It now also skips files that are readonly or start with a dot.